### PR TITLE
Use Displayname for Accessory name. Fix deviceDiscovery missing expected data.

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,8 +87,15 @@ SengledHubPlatform.prototype.deviceDiscovery = function() {
 				me.addAccessory(devices[i]);
 			} else {
 				existing.status = devices[i].status;
-                existing.brightness = devices[i].brightness;
-                existing.colorTemperature = devices[i].colorTemperature;
+                		existing.brightness = devices[i].brightness;
+                		existing.colorTemperature = devices[i].colorTemperature;
+				existing.colorMode = devices[i].colorMode;
+				existing.rgbColorR = devices[i].rgbColorR;
+				existing.rgbColorG = devices[i].rgbColorG;
+				existing.rgbColorB = devices[i].rgbColorB
+				existing.isOnline = devices[i].isOnline;
+				existing.signalQuality = devices[i].signalQuality;
+
 				if (me.debug) me.log("Skipping existing device", i);
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -125,9 +125,10 @@ SengledHubPlatform.prototype.addAccessory = function(data) {
 
 	if (!this.accessories[data.id]) {
 		let uuid = UUIDGen.generate(data.id);
+		let displayName = !(data.name) ? data.id : data.name;
 		// 5 == Accessory.Categories.LIGHTBULB
 		// 8 == Accessory.Categories.SWITCH
-		var newAccessory = new Accessory(data.id, uuid, 5);
+		var newAccessory = new Accessory(displayName, uuid, 5);
 		newAccessory.context.name = data.name;
 		newAccessory.context.id = data.id;
 		newAccessory.context.cb = null;

--- a/lib/client.js
+++ b/lib/client.js
@@ -102,24 +102,27 @@ module.exports = class ElementHomeClient {
 		}
 		
 		return new Promise((fulfill, reject) => {
-			this.client.post('/room/getUserRoomsDetail.json', {})
+			this.client.post('/device/getDeviceDetails.json', {})
 				.then((response) => {
 					if (response.data.ret == 100) {
 						reject(response.data);
 					} else {
-						let roomList = response.data.roomList
-						let deviceList = _ArrayFlatMap(roomList, i => i.deviceList);
-						deviceList = deviceList.concat(response.data.deviceNoRoomList);
-						let devices = deviceList.map((device) => {
+						let deviceInfos = response.data.deviceInfos;
+						let lampInfos = _ArrayFlatMap(deviceInfos, i => i.lampInfos);
+						let devices = lampInfos.map((device) => {
 							var newDevice = {
 								id: device.deviceUuid,
-								name: device.deviceName,
-								status: device.onoff,
-								brightness: device.brightness,
-								colortemperature: device.colortemperature,
-								isOnline: device.isOnline,
-								signalQuality: device.signalQuality,
-								productCode: device.productCode
+								name: device.attributes.name,
+								status: device.attributes.onoff,
+								brightness: device.attributes.brightness,
+								colortemperature: device.attributes.colorTemperature,
+								isOnline: device.attributes.isOnline,
+								signalQuality: device.attributes.deviceRssi,
+								productCode: device.attributes.productCode,
+								colorMode: device.attributes.colorMode,
+								rgbColorR: device.attributes.rgbColorR,
+								rgbColorG: device.attributes.rgbColorG,
+								rgbColorB: device.attributes.rgbColorB
 							};
 							me.cache[newDevice.id] = newDevice;
 							me.lastCache = moment();


### PR DESCRIPTION
Modify addAccessory to use the Sengled displayname when available, and fallback to the deviceid if not:

https://github.com/RandyTidd/homebridge-sengled-bulbs/pull/1

Modify device discovery to fix missing brighness, colortemperature and signalstrength.  I suspect the API changed, but I've only tested with E12-N1E.  Also add additional fields colorMode and rgbcolor* for RGBW bulbs.  No support for setting hue/saturation yet.

https://github.com/RandyTidd/homebridge-sengled-bulbs/issues/2