### PR TITLE
Add RGB light support

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,12 +339,16 @@ SengledLightAccessory.prototype.getPowerState = function(callback) {
 	}).then((device) => {
 		if (typeof device === 'undefined') {
 			if (this.debug) this.log("Removing undefined device", this.getName());
-			this.platform.removeAccessory(this.accessory)
+			this.platform.removeAccessory(this.accessory);
 		} else {
 			if (this.debug) this.log("getPowerState complete: " + device.name + " " + this.getName() + " is " + device.status);
 			this.context.status = device.status;
 			callback(null, device.status);
 		}
+	}).catch((err) => {
+		this.log("Failed to get power state");
+		this.log(err.message);
+		callback(err);
 	});
 };
 
@@ -390,8 +394,8 @@ SengledLightAccessory.prototype.setColorTemperature = function(colortemperature,
 			// color temperature circle in the color temperature setting match-ish color temperature (warm blue
 			// to cool orange-ish).
 
-			this.lightbulbService.getCharacteristic(Characteristic.Saturation).updateValue(this.color.getSaturation());
 			this.lightbulbService.getCharacteristic(Characteristic.Hue).updateValue(this.color.getHue());
+			this.lightbulbService.getCharacteristic(Characteristic.Saturation).updateValue(this.color.getSaturation());
 		}
 		callback();
 	}).catch((err) => {
@@ -431,7 +435,7 @@ SengledLightAccessory.prototype.setSaturation = function(saturation, callback) {
 		this.color.setSaturation(saturation);
 
 		let normalizedRgb = this.color.getRgb();
-		let rgbColor = Color.NormailizedRgbToSengledRgb(normalizedRgb.r, normalizedRgb.g, normalizedRgb.b );
+		let rgbColor = Color.NormalizedRgbToSengledRgb(normalizedRgb);
 
 		if (this.debug) this.log("++++ Sending device: " + this.getName() + " rgb color to " + "r: " + rgbColor.r + " g: " + rgbColor.g + " b: " + rgbColor.b );
 

--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ class SengledLightAccessory {
 		this.platform = platform;
 
 		this.brightness = new Brightness(this.context.brightness);
-		this.color = new Color(this.context.color);
+		this.color = new Color(this.context.color, this.log);
 
 		this.lightbulbService = accessory.getService(Service.Lightbulb)
 			|| accessory.addService(Service.Lightbulb);
@@ -389,8 +389,9 @@ SengledLightAccessory.prototype.setColorTemperature = function(colortemperature,
 			// The light is now in "white light" mode.  Update hue and saturation to homekit.  This makes the
 			// color temperature circle in the color temperature setting match-ish color temperature (warm blue
 			// to cool orange-ish).
-			this.lightbulbService.getCharacteristic(Characteristic.Hue).updateValue(this.color.getHue());
+
 			this.lightbulbService.getCharacteristic(Characteristic.Saturation).updateValue(this.color.getSaturation());
+			this.lightbulbService.getCharacteristic(Characteristic.Hue).updateValue(this.color.getHue());
 		}
 		callback();
 	}).catch((err) => {
@@ -415,6 +416,7 @@ SengledLightAccessory.prototype.setHue = function(hue, callback) {
 
 SengledLightAccessory.prototype.getHue = function(callback) {
 	if (this.debug) this.log("+++getHue: " + this.name + "  hue: " + this.color.getHue());
+
 	callback(null, this.color.getHue());
 };
 
@@ -439,14 +441,9 @@ SengledLightAccessory.prototype.setSaturation = function(saturation, callback) {
 		// The light is now in "color light" mode.
 
 		// The sengled API for setting RGB turns on the light.  Ideally, this would behave like color temp, but
-		// but update to reality for now.
+		// but update to reflect light state for now.
 		this.context.status = true;
 		this.lightbulbService.getCharacteristic(Characteristic.On).updateValue(this.context.status);
-
-		// TODO: Should color temp be updated
-		//
-		//	this.lightbulbService.getCharacteristic(Characteristic.ColorTemperature).updateValue(this.color.getColorTemperature());
-		// }
 
 		callback();
 	}).catch((err) => {

--- a/index.js
+++ b/index.js
@@ -87,8 +87,15 @@ SengledHubPlatform.prototype.deviceDiscovery = function() {
 				me.addAccessory(devices[i]);
 			} else {
 				existing.status = devices[i].status;
-                existing.brightness = devices[i].brightness;
-                existing.colorTemperature = devices[i].colorTemperature;
+                		existing.brightness = devices[i].brightness;
+                		existing.colorTemperature = devices[i].colorTemperature;
+				existing.colorMode = devices[i].colorMode;
+				existing.rgbColorR = devices[i].rgbColorR;
+				existing.rgbColorG = devices[i].rgbColorG;
+				existing.rgbColorB = devices[i].rgbColorB
+				existing.isOnline = devices[i].isOnline;
+				existing.signalQuality = devices[i].signalQuality;
+
 				if (me.debug) me.log("Skipping existing device", i);
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -125,9 +125,10 @@ SengledHubPlatform.prototype.addAccessory = function(data) {
 
 	if (!this.accessories[data.id]) {
 		let uuid = UUIDGen.generate(data.id);
+		let displayName = !(data.name) ? data.id : data.name;
 		// 5 == Accessory.Categories.LIGHTBULB
 		// 8 == Accessory.Categories.SWITCH
-		var newAccessory = new Accessory(data.id, uuid, 5);
+		var newAccessory = new Accessory(displayName, uuid, 5);
 		newAccessory.context.name = data.name;
 		newAccessory.context.id = data.id;
 		newAccessory.context.cb = null;

--- a/index.js
+++ b/index.js
@@ -437,6 +437,12 @@ SengledLightAccessory.prototype.setSaturation = function(saturation, callback) {
 	}).then(() => {
 
 		// The light is now in "color light" mode.
+
+		// The sengled API for setting RGB turns on the light.  Ideally, this would behave like color temp, but
+		// but update to reality for now.
+		this.context.status = true;
+		this.lightbulbService.getCharacteristic(Characteristic.On).updateValue(this.context.status);
+
 		// TODO: Should color temp be updated
 		//
 		//	this.lightbulbService.getCharacteristic(Characteristic.ColorTemperature).updateValue(this.color.getColorTemperature());

--- a/lib/client.js
+++ b/lib/client.js
@@ -102,24 +102,27 @@ module.exports = class ElementHomeClient {
 		}
 		
 		return new Promise((fulfill, reject) => {
-			this.client.post('/room/getUserRoomsDetail.json', {})
+			this.client.post('/device/getDeviceDetails.json', {})
 				.then((response) => {
 					if (response.data.ret == 100) {
 						reject(response.data);
 					} else {
-						let roomList = response.data.roomList
-						let deviceList = _ArrayFlatMap(roomList, i => i.deviceList);
-						deviceList = deviceList.concat(response.data.deviceNoRoomList);
-						let devices = deviceList.map((device) => {
+						let deviceInfos = response.data.deviceInfos;
+						let lampInfos = _ArrayFlatMap(deviceInfos, i => i.lampInfos);
+						let devices = lampInfos.map((device) => {
 							var newDevice = {
 								id: device.deviceUuid,
-								name: device.deviceName,
-								status: device.onoff,
-								brightness: device.brightness,
-								colortemperature: device.colortemperature,
-								isOnline: device.isOnline,
-								signalQuality: device.signalQuality,
-								productCode: device.productCode
+								name: device.attributes.name,
+								status: device.attributes.onoff,
+								brightness: device.attributes.brightness,
+								colortemperature: device.attributes.colorTemperature,
+								isOnline: device.attributes.isOnline,
+								signalQuality: device.attributes.deviceRssi,
+								productCode: device.attributes.productCode,
+								colorMode: device.attributes.colorMode,
+								rgbColorR: device.attributes.rgbColorR,
+								rgbColorG: device.attributes.rgbColorG,
+								rgbColorB: device.attributes.rgbColorB
 							};
 							me.cache[newDevice.id] = newDevice;
 							me.lastCache = moment();

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,7 +6,7 @@ const cookieJar = new tough.CookieJar();
 
 let moment = require('moment');
 const https = require('https');
-let Color = require('./color');
+const {RgbColor, ColorContextData, Color, ColorModeRgb, ColorModeColorTemperature} = require('./color');
 
 function _ArrayFlatMap(array, selector) {
     if (array.length == 0) {
@@ -28,9 +28,44 @@ function _guid() {
     s4() + '-' + s4() + s4() + s4();
 }
 
+function Clamp(value, min, max) {
+	value = Math.min(value, max);
+	value = Math.max(value, min);
+	return value;
+}
 
+class BrightnessContextData {
+	constructor(value) {
+		this.value = value;
 
-module.exports = class ElementHomeClient {
+		// Configure min/max brightness so that it uses sengled API encoding [0-255].
+		const sengledMinBrightness = 0;
+		const sengledMaxBrightness = 255;
+
+		this.min = sengledMinBrightness;
+		this.max = sengledMaxBrightness;
+	}
+};
+
+class Brightness  {
+	constructor(brightnessContextData) {
+		this.data = brightnessContextData;
+	}
+
+	getValue() { return this.data.value; }
+	setValue(value) {
+		this.data.value = Clamp(value, this.data.min, this.data.max);
+	}
+
+	getMin() { return this.data.min; }
+	getMax() { return this.data.max; }
+
+	supportsBrightness() {
+		return this.data.value !== undefined;
+	}
+};
+
+class ElementHomeClient {
 
   constructor(log, debug = false, info = false) {
 
@@ -115,46 +150,62 @@ module.exports = class ElementHomeClient {
 						let lampInfos = _ArrayFlatMap(deviceInfos, i => i.lampInfos);
 						let devices = lampInfos.map((device) => {
 
-							let attributes = device.attributes;
+						let attributes = device.attributes;
 
-							let rgbColor = Color.SengledRgbToNormalizedRgb(
+						// Check for the existence of attributes to determine bulb capability
+						const supportsBrightness = attributes.hasOwnProperty('brightness');
+						const supportsColorTemperature = attributes.hasOwnProperty('colorTemperature');
+						const supportsRgbColor = attributes.hasOwnProperty('rgbColorR');
+
+						const brightnessValue = supportsBrightness ? attributes.brightness : undefined;
+						const brightnessContextData = new BrightnessContextData(brightnessValue);
+						const brightness = new Brightness(brightnessContextData);
+
+						const colorMode = attributes.hasOwnProperty('colorMode')
+							? attributes.colorMode
+							: supportsColorTemperature
+								? ColorModeColorTemperature
+								: ColorModeRgb;
+
+						const rgbColor = supportsRgbColor
+							? Color.SengledRgbToNormalizedRgb(
 								attributes.rgbColorR,
 								attributes.rgbColorG,
-								attributes.rgbColorB
-							);
+								attributes.rgbColorB)
+							: undefined;
 
-							let color = new Color(
-								attributes.colorMode,
-								Color.SengledColorTemperatureToMireds(attributes.colorTemperature),
-								rgbColor
-							);
+						const colorTemperature = supportsColorTemperature
+							? Color.SengledColorTemperatureToMireds(attributes.colorTemperature)
+							: undefined;
 
-							// Configure min/max brightness so that it uses sengled API encoding [0-255].
-							const sengledMinBrightness = 0;
-							const sengledMaxBrightness = 255;
+						const colorContextData = new ColorContextData(
+							colorMode,
+							colorTemperature,
+							rgbColor
+						);
 
-							let newDevice = {
-								id: device.deviceUuid,
-								name: device.attributes.name,
-								status: attributes.onoff,
-								isOnline: attributes.isOnline,
-								signalQuality: attributes.deviceRssi,
-								productCode: attributes.productCode,
-								brightness: attributes.brightness,
-								minBrightness: sengledMinBrightness,
-								maxBrightness: sengledMaxBrightness,
-								color: color
-							};
+						const color = new Color(colorContextData);
 
-							me.cache[newDevice.id] = newDevice;
-							me.lastCache = moment();
-							return newDevice;
-						});
-						fulfill(devices);
-					}
-				}).catch(function(error) {
-					reject(error);
-				});
+						let newDevice = {
+							id: device.deviceUuid,
+							name: attributes.name,
+							status: attributes.onoff,
+							isOnline: attributes.isOnline,
+							signalQuality: attributes.deviceRssi,
+							productCode: attributes.productCode,
+							brightness: brightness,
+							color: color
+						};
+
+						me.cache[newDevice.id] = newDevice;
+						me.lastCache = moment();
+						return newDevice;
+					});
+					fulfill(devices);
+				}
+			}).catch(function(error) {
+				reject(error);
+			});
 		});
 	}
 
@@ -258,3 +309,8 @@ deviceSetRgbColor(deviceId, rgb) {
     });
 }
 };
+
+module.exports = {
+	ElementHomeClient: ElementHomeClient,
+	Brightness: Brightness
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -152,7 +152,12 @@ class ElementHomeClient {
 
 						let attributes = device.attributes;
 
+						const firmwareVersion = attributes.hasOwnProperty('version')
+							? "V0.0." + attributes.version // Match the SengledHome app display format.
+							: undefined;
+
 						// Check for the existence of attributes to determine bulb capability
+						// This assumes that lights without a capability will not have unused attributes.
 						const supportsBrightness = attributes.hasOwnProperty('brightness');
 						const supportsColorTemperature = attributes.hasOwnProperty('colorTemperature');
 						const supportsRgbColor = attributes.hasOwnProperty('rgbColorR');
@@ -161,12 +166,16 @@ class ElementHomeClient {
 						const brightnessContextData = new BrightnessContextData(brightnessValue);
 						const brightness = new Brightness(brightnessContextData);
 
+						// colorMode should be supplied if both colorTemperature and rgb are supported.
+						// Unknown if it is supplied for lights that support one or none of these, so
+						// choose a default if undefined.
 						const colorMode = attributes.hasOwnProperty('colorMode')
 							? attributes.colorMode
 							: supportsColorTemperature
 								? ColorModeColorTemperature
 								: ColorModeRgb;
 
+						// Color class expects normalized RGB.
 						const rgbColor = supportsRgbColor
 							? Color.SengledRgbToNormalizedRgb(
 								attributes.rgbColorR,
@@ -174,18 +183,27 @@ class ElementHomeClient {
 								attributes.rgbColorB)
 							: undefined;
 
+						// Retrieve color configuration based on product code.  Unknown models get defaulted values
+						const colorConfigData = Color.GetConfigData(attributes.productCode);
+
+						// Color class expects temperature in mireds.  This assumes a linear conversion
+						// from the sengled encoded range.
 						const colorTemperature = supportsColorTemperature
-							? Color.SengledColorTemperatureToMireds(attributes.colorTemperature)
+							? Color.SengledColorTemperatureToMireds(attributes.colorTemperature, colorConfigData)
 							: undefined;
 
+						// Color data that can be serialized and deserialized.
 						const colorContextData = new ColorContextData(
+							colorConfigData,
 							colorMode,
 							colorTemperature,
 							rgbColor
 						);
 
+						// Wrap the color data to provide functionality.
 						const color = new Color(colorContextData);
 
+						// Sengled device data
 						let newDevice = {
 							id: device.deviceUuid,
 							name: attributes.name,
@@ -193,10 +211,12 @@ class ElementHomeClient {
 							isOnline: attributes.isOnline,
 							signalQuality: attributes.deviceRssi,
 							productCode: attributes.productCode,
+							firmwareVersion: firmwareVersion,
 							brightness: brightness,
 							color: color
 						};
 
+						// Cache this device and set the last time the cache was updated.
 						me.cache[newDevice.id] = newDevice;
 						me.lastCache = moment();
 						return newDevice;

--- a/lib/client.js
+++ b/lib/client.js
@@ -177,10 +177,10 @@ class ElementHomeClient {
 
 						// Color class expects normalized RGB.
 						const rgbColor = supportsRgbColor
-							? Color.SengledRgbToNormalizedRgb(
+							? Color.SengledRgbToNormalizedRgb(new RgbColor(
 								attributes.rgbColorR,
 								attributes.rgbColorG,
-								attributes.rgbColorB)
+								attributes.rgbColorB))
 							: undefined;
 
 						// Retrieve color configuration based on product code.  Unknown models get defaulted values
@@ -201,7 +201,7 @@ class ElementHomeClient {
 						);
 
 						// Wrap the color data to provide functionality.
-						const color = new Color(colorContextData);
+						const color = new Color(colorContextData, this.log);
 
 						// Sengled device data
 						let newDevice = {

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,7 @@ const cookieJar = new tough.CookieJar();
 
 let moment = require('moment');
 const https = require('https');
+let Color = require('./color');
 
 function _ArrayFlatMap(array, selector) {
     if (array.length == 0) {
@@ -27,9 +28,9 @@ function _guid() {
     s4() + '-' + s4() + s4() + s4();
 }
 
+
+
 module.exports = class ElementHomeClient {
-
-
 
   constructor(log, debug = false, info = false) {
 
@@ -91,16 +92,19 @@ module.exports = class ElementHomeClient {
 
   }
 
+
   getDevices() {
+
 		let me = this;
 		if (me.debug) me.log("getDevices invoked ");
+
 		if (me.debug) me.log(me.cache);
 		if (me.debug) me.log(moment() - me.lastCache);
 		if (moment() - me.lastCache <= 2000){
 			if (me.debug) me.log("######getDevices from cache ");
-			me.cache.map((device) => {return newDevice;});
+			me.cache.map((device) => {return device;});
 		}
-		
+
 		return new Promise((fulfill, reject) => {
 			this.client.post('/device/getDeviceDetails.json', {})
 				.then((response) => {
@@ -110,20 +114,38 @@ module.exports = class ElementHomeClient {
 						let deviceInfos = response.data.deviceInfos;
 						let lampInfos = _ArrayFlatMap(deviceInfos, i => i.lampInfos);
 						let devices = lampInfos.map((device) => {
-							var newDevice = {
+
+							let attributes = device.attributes;
+
+							let rgbColor = Color.SengledRgbToNormalizedRgb(
+								attributes.rgbColorR,
+								attributes.rgbColorG,
+								attributes.rgbColorB
+							);
+
+							let color = new Color(
+								attributes.colorMode,
+								Color.SengledColorTemperatureToMireds(attributes.colorTemperature),
+								rgbColor
+							);
+
+							// Configure min/max brightness so that it uses sengled API encoding [0-255].
+							const sengledMinBrightness = 0;
+							const sengledMaxBrightness = 255;
+
+							let newDevice = {
 								id: device.deviceUuid,
 								name: device.attributes.name,
-								status: device.attributes.onoff,
-								brightness: device.attributes.brightness,
-								colortemperature: device.attributes.colorTemperature,
-								isOnline: device.attributes.isOnline,
-								signalQuality: device.attributes.deviceRssi,
-								productCode: device.attributes.productCode,
-								colorMode: device.attributes.colorMode,
-								rgbColorR: device.attributes.rgbColorR,
-								rgbColorG: device.attributes.rgbColorG,
-								rgbColorB: device.attributes.rgbColorB
+								status: attributes.onoff,
+								isOnline: attributes.isOnline,
+								signalQuality: attributes.deviceRssi,
+								productCode: attributes.productCode,
+								brightness: attributes.brightness,
+								minBrightness: sengledMinBrightness,
+								maxBrightness: sengledMaxBrightness,
+								color: color
 							};
+
 							me.cache[newDevice.id] = newDevice;
 							me.lastCache = moment();
 							return newDevice;
@@ -198,6 +220,30 @@ deviceSetColorTemperature(deviceId, colorTemperature) {
             .post('/device/deviceSetColorTemperature.json', {
                 colorTemperature: colorTemperature,
                 deviceUuid: deviceId
+            })
+            .then(response => {
+                if (response.data.ret == 100) {
+                    reject(response.data);
+                } else {
+                    fulfill(response);
+                }
+            })
+            .catch(function(error) {
+                reject(error);
+            });
+    });
+}
+
+// r: 0-255, g: 0-255, b: 0-255
+deviceSetRgbColor(deviceId, rgb) {
+    return new Promise((fulfill, reject) => {
+        this.client
+            .post('/device/deviceSetGroup.json', {
+		cmdId: 129,
+		deviceUuidList: [{ deviceUuid: deviceId}],
+		rgbColorR: rgb.r,
+		rgbColorG: rgb.g,
+		rgbColorB: rgb.b
             })
             .then(response => {
                 if (response.data.ret == 100) {

--- a/lib/color.js
+++ b/lib/color.js
@@ -1,34 +1,28 @@
 const homebridgeLib = require('homebridge-lib')
 const {
-   xyToHsv, hsvToXy, hsvToRgb, ctToXy, rgbToHsv, defaultGamut
+   hsvToRgb, rgbToHsv
 } = homebridgeLib.Colour
 
 
 class ColorConfigData {
-	constructor(maxColorTemperature, minColorTemperature, gamut) {
+	constructor(maxColorTemperature, minColorTemperature) {
 		this.maxColorTemperature = maxColorTemperature;
 		this.minColorTemperature = minColorTemperature;
-		this.gamut = gamut;
 	}
 };
 
 const defaultColorConfigData = new ColorConfigData(
 	 500,		// Mireds: 2000k - homekit default
 	 140,		// Mireds: ~7143k - homekit default
-	 defaultGamut	// default from homebrige-lib.
 );
 
 // Config for Lights: E12-N1E
 const colorConfigData1 = new ColorConfigData(
 	500, // Mireds: 2000k
 	154, // Mireds: ~6500k
-	{ // gamut values from an online forum post indicating they were sniffed from zigbee
-		r: [0.733, 0.264],
-		g: [0.116, 0.818],
-		b: [0.157, 0.019]
-	}
 );
 
+// Each ColorConfigData has an arra of lights that it applies to.
 const colorConfigs = [
 	{data: colorConfigData1, productCodes: ['E12-N1E'] }
 ];
@@ -44,9 +38,15 @@ const sengledMaxColorTemperature = 100;
 const sengledMinColorTemperature = 0;
 
 function assert(condition, message) {
-    if (!condition) {
-        throw new Error(message || "Assertion failed");
-    }
+	if (!condition) {
+		throw new Error(message || "Assertion failed");
+	}
+}
+
+function Clamp(value, min, max) {
+	value = Math.min(value, max);
+	value = Math.max(value, min);
+	return value;
 }
 
 class RgbColor {
@@ -72,13 +72,18 @@ class Color {
 	constructor(colorContextData) {
 		this.data = colorContextData;
 
+
 		if (this.supportsColorTemperature() && this.supportsRgb())
 		{
 			// Sync colorTemperature and rgbColor based on current color mode.
 			const hsv = (() => {
-				return (this.getColorMode() == ColorModeColorTemperature)
-					? xyToHsv(ctToXy(this.getColorTemperature(), this.getGamut()))
-					: rgbToHsv(this.getRgb().r, this.getRgb().g, this.getRgb().b);
+
+				if (this.getColorMode() == ColorModeColorTemperature) {
+					let rgb = Color.MiredsToRgb(this.getColorTemperature());
+					return rgbToHsv(rgb.r, rgb.g, rgb.b);
+				}
+
+				return  rgbToHsv(this.getRgb().r, this.getRgb().g, this.getRgb().b);
 			})();
 
 			this.data.hue = hsv.h;
@@ -104,14 +109,8 @@ class Color {
 
 		if (this.supportsRgb())
 		{
-			const xy = ctToXy(mireds);
-			const {h, s} = xyToHsv(xy, this.getGamut());
-
-			this.data.hue = h;
-			this.data.saturation = s;
-
-			this.updateFromHsv();
-
+			let rgb = Color.MiredsToRgb(mireds);
+			this.updateHsvFromRgb(rgb);
 			this.data.colorMode = ColorModeColorTemperature;
 		}
 	}
@@ -133,6 +132,15 @@ class Color {
 	}
 
 	getRgb() { return this.data.rgbColor; }
+
+	updateHsvFromRgb(rgb) {
+
+		const {h, s, v} = rgbToHsv(rgb.r, rgb.g, rgb.b);
+
+		this.data.hue = h;
+		this.data.saturation = s;
+	}
+
 	updateFromHsv() {
 		this.data.rgbColor = hsvToRgb(this.data.hue, this.data.saturation);
 	}
@@ -161,20 +169,28 @@ class Color {
 		return colorConfig != undefined ? colorConfig.data : defaultColorConfig;
 	}
 
+	static ByteRgbToNormalizedRgb(r, g, b) {
+		return new RgbColor(
+			r / 255.0,
+			g / 255.0,
+			b / 255.0
+		);
+	}
+
 	static SengledRgbToNormalizedRgb(r, g, b) {
-		return {
-			r: r / 255.0,
-			g: g / 255.0,
-			b: b / 255.0
-		};
+		return Color.ByteRgbToNormalizedRgb(r, g, b);
+	}
+
+	static NormailizedRgbToByteRgb(r, g, b) {
+		return new RgbColor(
+			Math.round(r * 255),
+			Math.round(g * 255),
+			Math.round(b * 255)
+		);
 	}
 
 	static NormailizedRgbToSengledRgb(r, g, b) {
-		return {
-			r: Math.round(r * 255),
-			g: Math.round(g * 255),
-			b: Math.round(b * 255)
-		};
+		return Color.NormalizedRgbToByteRgb(r, g, b);
 	}
 
 	static SengledColorTemperatureToMireds(colorTemperature, configData) {
@@ -201,6 +217,84 @@ class Color {
 			sengledMaxColorTemperature,
 			sengledMinColorTemperature
 		));
+	}
+
+	static MiredsToKelvins(mireds) {
+		return Math.round(1000000.0 / mireds);
+	}
+
+	static KelvinsToMireds(kelvins) {
+		return Math.round(1000000.0 / kelvins);
+	}
+
+	static MiredsToRgb(mireds) {
+		let kelvin = Color.MiredsToKelvins(mireds);
+		return Color.KelvinsToRgb(kelvin);
+	}
+
+	// Adapted from Tanner Helland's algorithm:
+	// https://tannerhelland.com/2012/09/18/convert-temperature-rgb-algorithm-code.html
+	// Modified to produce normailized rgb.
+	static KelvinsToRgb(tmpKelvin) {
+
+		let tmpCalc, r, g, b;
+
+		// Temperature must fall between 1000 and 40000 degrees
+		tmpKelvin = Clamp(tmpKelvin, 1000, 40000);
+
+		// All calculations require tmpKelvin \ 100, so only do the conversion once
+		tmpKelvin = Math.floor(tmpKelvin / 100.0);
+
+		// Calculate each color in turn
+
+		// First: red
+		if (tmpKelvin <= 66){
+			r = 1.0;
+		}
+		else {
+			// Note: the R-squared value for this approximation is .988
+			tmpCalc = tmpKelvin - 60;
+			tmpCalc = 329.698727446 * Math.pow(tmpCalc, -0.1332047592);
+			tmpCalc = tmpCalc / 255.0;
+
+			r = Clamp(tmpCalc, 0.0, 1.0);
+		}
+
+		// Second: green
+		if(tmpKelvin <= 66) {
+			// Note: the R-squared value for this approximation is .996
+			tmpCalc = tmpKelvin;
+			tmpCalc = 99.4708025861 * Math.log(tmpCalc) - 161.1195681661;
+			tmpCalc = tmpCalc / 255.0;
+
+			g = Clamp(tmpCalc, 0.0, 1.0);
+		}
+		else {
+			//Note: the R-squared value for this approximation is .987
+			tmpCalc = tmpKelvin - 60;
+			tmpCalc = 288.1221695283 * Math.pow(tmpCalc, -0.0755148492);
+			tmpCalc = tmpCalc / 255.0;
+
+			g = Clamp(tmpCalc, 0.0, 1.0);
+		}
+
+		// Third: blue
+		if (tmpKelvin >= 66) {
+			b = 1.0;
+		}
+		else if(tmpKelvin <= 19) {
+			b = 0.0;
+		}
+		else {
+			// Note: the R-squared value for this approximation is .998
+			tmpCalc = tmpKelvin - 10;
+			tmpCalc = 138.5177312231 * Math.log(tmpCalc) - 305.0447927307;
+			tmpCalc = tmpCalc / 255.0;
+
+			b = Clamp(tmpCalc, 0.0, 1.0);
+		}
+
+		return new RgbColor(r, g, b);
 	}
 };
 

--- a/lib/color.js
+++ b/lib/color.js
@@ -1,24 +1,43 @@
 const homebridgeLib = require('homebridge-lib')
 const {
-   xyToHsv, hsvToXy, hsvToRgb, ctToXy, rgbToHsv
+   xyToHsv, hsvToXy, hsvToRgb, ctToXy, rgbToHsv, defaultGamut
 } = homebridgeLib.Colour
 
-// Sengled sniffed packets: [{"x":0.733,"y":0.264}, {"x":0.116,"y":0.818}, {"x":0.157,"y":0.019}]
 
-const gamut = {
-      r: [0.733, 0.264],
-      g: [0.116, 0.818],
-      b: [0.157, 0.019]
+class ColorConfigData {
+	constructor(maxColorTemperature, minColorTemperature, gamut) {
+		this.maxColorTemperature = maxColorTemperature;
+		this.minColorTemperature = minColorTemperature;
+		this.gamut = gamut;
+	}
 };
+
+const defaultColorConfigData = new ColorConfigData(
+	 500,		// Mireds: 2000k - homekit default
+	 140,		// Mireds: ~7143k - homekit default
+	 defaultGamut	// default from homebrige-lib.
+);
+
+// Config for Lights: E12-N1E
+const colorConfigData1 = new ColorConfigData(
+	500, // Mireds: 2000k
+	154, // Mireds: ~6500k
+	{ // gamut values from an online forum post indicating they were sniffed from zigbee
+		r: [0.733, 0.264],
+		g: [0.116, 0.818],
+		b: [0.157, 0.019]
+	}
+);
+
+const colorConfigs = [
+	{data: colorConfigData1, productCodes: ['E12-N1E'] }
+];
 
 const scaleRange = (value, currentMin, currentMax, newMin, newMax) =>
 	((value - currentMin) * (newMax - newMin)) / (currentMax - currentMin) + newMin;
 
 const ColorModeColorTemperature = 2;
 const ColorModeRgb = 1;
-
-const sengledMaxColorTemperatureMireds = 500; // Mireds: 2000k
-const sengledMinColorTemperatureMireds = 154; // Mireds: ~6500k
 
 // Note: Mired min maps to max sengled encoding, and mired max maps to min sengled encoding
 const sengledMaxColorTemperature = 100;
@@ -30,8 +49,7 @@ function assert(condition, message) {
     }
 }
 
-class RgbColor
-{
+class RgbColor {
 	constructor(r, g, b) {
 		this.r = r;
 		this.g = g;
@@ -40,15 +58,13 @@ class RgbColor
 };
 
 class ColorContextData {
-	constructor(colorMode, colorTemperature, rgbColor, hue = 0, saturation = 0) {
+	constructor(colorConfigData, colorMode, colorTemperature, rgbColor, hue = 0, saturation = 0) {
+		this.configData = colorConfigData;
 		this.colorMode = colorMode;
 		this.colorTemperature = colorTemperature;
 		this.rgbColor = rgbColor;
 		this.hue = hue;
 		this.saturation = saturation;
-
-		this.maxColorTemperature = sengledMaxColorTemperatureMireds;
-		this.minColorTemperature = sengledMinColorTemperatureMireds;
 	}
 };
 
@@ -61,7 +77,7 @@ class Color {
 			// Sync colorTemperature and rgbColor based on current color mode.
 			const hsv = (() => {
 				return (this.getColorMode() == ColorModeColorTemperature)
-					? xyToHsv(ctToXy(this.getColorTemperature(), gamut))
+					? xyToHsv(ctToXy(this.getColorTemperature(), this.getGamut()))
 					: rgbToHsv(this.getRgb().r, this.getRgb().g, this.getRgb().b);
 			})();
 
@@ -75,8 +91,10 @@ class Color {
 	supportsColorTemperature() { return this.data.colorTemperature !== undefined;}
 	supportsRgb() { return this.data.rgbColor !== undefined; }
 
-	getMinColorTemperature() { return this.data.minColorTemperature; }
-	getMaxColorTemperature() { return this.data.maxColorTemperature; }
+	getMinColorTemperature() { return this.getConfigData().minColorTemperature; }
+	getMaxColorTemperature() { return this.getConfigData().maxColorTemperature; }
+	getGamut() { return this.getConfigData().gamut; }
+	getConfigData() { return this.data.configData; }
 
 	getColorTemperature() { return this.data.colorTemperature; }
 	setColorTemperature(mireds) {
@@ -87,7 +105,7 @@ class Color {
 		if (this.supportsRgb())
 		{
 			const xy = ctToXy(mireds);
-			const {h, s} = xyToHsv(xy, gamut);
+			const {h, s} = xyToHsv(xy, this.getGamut());
 
 			this.data.hue = h;
 			this.data.saturation = s;
@@ -119,6 +137,30 @@ class Color {
 		this.data.rgbColor = hsvToRgb(this.data.hue, this.data.saturation);
 	}
 
+	// Deep copy context data
+	copyData() {
+		return JSON.parse(JSON.stringify(this.data));
+	}
+
+	// Shallow assign context data
+	assignData(colorContextData) {
+		this.data = Object.assign(this.data, colorContextData);
+	}
+
+	// Lookup color configuration by product code from the color config data table.
+	static GetConfigData(productCode) {
+
+		const colorConfig = colorConfigs.find(
+			colorConfig => colorConfig.productCodes.find(
+					productCode => productCode.toUpperCase() === productCode.toUpperCase()
+			) != undefined
+		);
+
+		if (colorConfig != undefined)
+
+		return colorConfig != undefined ? colorConfig.data : defaultColorConfig;
+	}
+
 	static SengledRgbToNormalizedRgb(r, g, b) {
 		return {
 			r: r / 255.0,
@@ -135,21 +177,27 @@ class Color {
 		};
 	}
 
-	static SengledColorTemperatureToMireds(colorTemperature) {
+	static SengledColorTemperatureToMireds(colorTemperature, configData) {
+		// Assumes a linear maping of ranges.
+		// Min Sengled encoding represents max mired value (the lowest color temperature)
+		// and vice versa, so the ranges are swapped when scaling.
 		return Math.round(scaleRange(
 			colorTemperature,
 			sengledMinColorTemperature,
 			sengledMaxColorTemperature,
-			sengledMaxColorTemperatureMireds,
-			sengledMinColorTemperatureMireds
+			configData.maxColorTemperature,
+			configData.minColorTemperature
 		));
 	}
 
-	static MiredsToSengledColorTemperature(colorTemperature) {
+	static MiredsToSengledColorTemperature(colorTemperature, configData) {
+		// Assumes a linear maping of ranges.
+		// Min Sengled encoding represents max mired value (the lowest color temperature)
+		// and vice versa, so the ranges are swapped when scaling.
 		return Math.round(scaleRange(
 			colorTemperature,
-			sengledMinColorTemperatureMireds,
-			sengledMaxColorTemperatureMireds,
+			configData.minColorTemperature,
+			configData.maxColorTemperature,
 			sengledMaxColorTemperature,
 			sengledMinColorTemperature
 		));

--- a/lib/color.js
+++ b/lib/color.js
@@ -6,16 +6,16 @@ const {
 // Sengled sniffed packets: [{"x":0.733,"y":0.264}, {"x":0.116,"y":0.818}, {"x":0.157,"y":0.019}]
 
 const gamut = {
-      r: [0.7006, 0.2993],
-      g: [0.1387, 0.8148],
-      b: [0.1510, 0.0227]
+      r: [0.733, 0.264],
+      g: [0.116, 0.818],
+      b: [0.157, 0.019]
 };
 
 const scaleRange = (value, currentMin, currentMax, newMin, newMax) =>
 	((value - currentMin) * (newMax - newMin)) / (currentMax - currentMin) + newMin;
 
-const ColorModeColorTemperature = 1;
-const ColorModeRGB = 2;
+const ColorModeColorTemperature = 2;
+const ColorModeRgb = 1;
 
 const sengledMaxColorTemperatureMireds = 500; // Mireds: 2000k
 const sengledMinColorTemperatureMireds = 154; // Mireds: ~6500k
@@ -24,52 +24,99 @@ const sengledMinColorTemperatureMireds = 154; // Mireds: ~6500k
 const sengledMaxColorTemperature = 100;
 const sengledMinColorTemperature = 0;
 
-module.exports = class Color
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message || "Assertion failed");
+    }
+}
+
+class RgbColor
 {
-	constructor(colorMode, colorTemperature, rgbColor) {
+	constructor(r, g, b) {
+		this.r = r;
+		this.g = g;
+		this.b = b;
+	}
+};
+
+class ColorContextData {
+	constructor(colorMode, colorTemperature, rgbColor, hue = 0, saturation = 0) {
 		this.colorMode = colorMode;
 		this.colorTemperature = colorTemperature;
 		this.rgbColor = rgbColor;
-
-		const hsv = (() => {
-			return (colorMode == ColorModeColorTemperature)
-				? xyToHsv(ctToXy(this.colorTemperature))
-				: rgbToHsv(this.rgbColor.r, this.rgbColor.g, this.rgbColor.b);
-		})();
-
-		this.hue = hsv.h;
-		this.saturation = hsv.s;
+		this.hue = hue;
+		this.saturation = saturation;
 
 		this.maxColorTemperature = sengledMaxColorTemperatureMireds;
 		this.minColorTemperature = sengledMinColorTemperatureMireds;
 	}
+};
 
-	SetColorTemperature(mireds) {
-		const xy = ctToXy(mireds);
-		const {h, s} = xyToHsv(xy);
+class Color {
+	constructor(colorContextData) {
+		this.data = colorContextData;
 
-		this.hue = h;
-		this.saturation = s;
+		if (this.supportsColorTemperature() && this.supportsRgb())
+		{
+			// Sync colorTemperature and rgbColor based on current color mode.
+			const hsv = (() => {
+				return (this.getColorMode() == ColorModeColorTemperature)
+					? xyToHsv(ctToXy(this.getColorTemperature(), gamut))
+					: rgbToHsv(this.getRgb().r, this.getRgb().g, this.getRgb().b);
+			})();
 
-		this.UpdateFromHsv();
-
-		this.colorMode = ColorModeColorTemperature;
+			this.data.hue = hsv.h;
+			this.data.saturation = hsv.s;
+		}
 	}
 
-	SetHue(hue) {
-		this.hue = hue;
-		this.UpdateFromHsv();
-		this.colorMode = ColorModeRGB;
+	getColorMode() { return this.data.colorMode; }
+
+	supportsColorTemperature() { return this.data.colorTemperature !== undefined;}
+	supportsRgb() { return this.data.rgbColor !== undefined; }
+
+	getMinColorTemperature() { return this.data.minColorTemperature; }
+	getMaxColorTemperature() { return this.data.maxColorTemperature; }
+
+	getColorTemperature() { return this.data.colorTemperature; }
+	setColorTemperature(mireds) {
+
+		assert(this.supportsColorTemperature(), 'Must not set colorTemperature when it is unsupported.');
+		this.data.colorTemperature = mireds;
+
+		if (this.supportsRgb())
+		{
+			const xy = ctToXy(mireds);
+			const {h, s} = xyToHsv(xy, gamut);
+
+			this.data.hue = h;
+			this.data.saturation = s;
+
+			this.updateFromHsv();
+
+			this.data.colorMode = ColorModeColorTemperature;
+		}
 	}
 
-	SetSaturation(saturation) {
-		this.saturation = saturation;
-		this.UpdateFromHsv();
-		this.colorMode = ColorModeRGB;
+	getHue() { return this.data.hue; }
+	setHue(hue) {
+		assert(this.supportsRgb(), 'Must not set hue when rgbColor is unsupported.');
+		this.data.hue = hue;
+		this.updateFromHsv();
+		this.data.colorMode = ColorModeRgb;
 	}
 
-	UpdateFromHsv() {
-		this.rgbColor = hsvToRgb(this.hue, this.saturation);
+	getSaturation() { return this.data.saturation; }
+	setSaturation(saturation) {
+		assert(this.supportsRgb(), 'Must not set saturation when rgbColor is unsupported.');
+		this.data.saturation = saturation;
+		this.updateFromHsv();
+		this.data.colorMode = ColorModeRgb;
+	}
+
+	getRgb() { return this.data.rgbColor; }
+	updateFromHsv() {
+		this.data.rgbColor = hsvToRgb(this.data.hue, this.data.saturation);
 	}
 
 	static SengledRgbToNormalizedRgb(r, g, b) {
@@ -109,3 +156,10 @@ module.exports = class Color
 	}
 };
 
+module.exports = {
+	RgbColor: RgbColor,
+	ColorContextData: ColorContextData,
+	Color: Color,
+	ColorModeRgb: ColorModeRgb,
+	ColorModeColorTemperature: ColorModeColorTemperature
+}

--- a/lib/color.js
+++ b/lib/color.js
@@ -1,0 +1,111 @@
+const homebridgeLib = require('homebridge-lib')
+const {
+   xyToHsv, hsvToXy, hsvToRgb, ctToXy, rgbToHsv
+} = homebridgeLib.Colour
+
+// Sengled sniffed packets: [{"x":0.733,"y":0.264}, {"x":0.116,"y":0.818}, {"x":0.157,"y":0.019}]
+
+const gamut = {
+      r: [0.7006, 0.2993],
+      g: [0.1387, 0.8148],
+      b: [0.1510, 0.0227]
+};
+
+const scaleRange = (value, currentMin, currentMax, newMin, newMax) =>
+	((value - currentMin) * (newMax - newMin)) / (currentMax - currentMin) + newMin;
+
+const ColorModeColorTemperature = 1;
+const ColorModeRGB = 2;
+
+const sengledMaxColorTemperatureMireds = 500; // Mireds: 2000k
+const sengledMinColorTemperatureMireds = 154; // Mireds: ~6500k
+
+// Note: Mired min maps to max sengled encoding, and mired max maps to min sengled encoding
+const sengledMaxColorTemperature = 100;
+const sengledMinColorTemperature = 0;
+
+module.exports = class Color
+{
+	constructor(colorMode, colorTemperature, rgbColor) {
+		this.colorMode = colorMode;
+		this.colorTemperature = colorTemperature;
+		this.rgbColor = rgbColor;
+
+		const hsv = (() => {
+			return (colorMode == ColorModeColorTemperature)
+				? xyToHsv(ctToXy(this.colorTemperature))
+				: rgbToHsv(this.rgbColor.r, this.rgbColor.g, this.rgbColor.b);
+		})();
+
+		this.hue = hsv.h;
+		this.saturation = hsv.s;
+
+		this.maxColorTemperature = sengledMaxColorTemperatureMireds;
+		this.minColorTemperature = sengledMinColorTemperatureMireds;
+	}
+
+	SetColorTemperature(mireds) {
+		const xy = ctToXy(mireds);
+		const {h, s} = xyToHsv(xy);
+
+		this.hue = h;
+		this.saturation = s;
+
+		this.UpdateFromHsv();
+
+		this.colorMode = ColorModeColorTemperature;
+	}
+
+	SetHue(hue) {
+		this.hue = hue;
+		this.UpdateFromHsv();
+		this.colorMode = ColorModeRGB;
+	}
+
+	SetSaturation(saturation) {
+		this.saturation = saturation;
+		this.UpdateFromHsv();
+		this.colorMode = ColorModeRGB;
+	}
+
+	UpdateFromHsv() {
+		this.rgbColor = hsvToRgb(this.hue, this.saturation);
+	}
+
+	static SengledRgbToNormalizedRgb(r, g, b) {
+		return {
+			r: r / 255.0,
+			g: g / 255.0,
+			b: b / 255.0
+		};
+	}
+
+	static NormailizedRgbToSengledRgb(r, g, b) {
+		return {
+			r: Math.round(r * 255),
+			g: Math.round(g * 255),
+			b: Math.round(b * 255)
+		};
+	}
+
+	static SengledColorTemperatureToMireds(colorTemperature) {
+		return Math.round(scaleRange(
+			colorTemperature,
+			sengledMinColorTemperature,
+			sengledMaxColorTemperature,
+			sengledMaxColorTemperatureMireds,
+			sengledMinColorTemperatureMireds
+		));
+	}
+
+	static MiredsToSengledColorTemperature(colorTemperature) {
+		return Math.round(scaleRange(
+			colorTemperature,
+			sengledMinColorTemperatureMireds,
+			sengledMaxColorTemperatureMireds,
+			sengledMaxColorTemperature,
+			sengledMinColorTemperature
+		));
+	}
+};
+

--- a/lib/color.js
+++ b/lib/color.js
@@ -1,8 +1,3 @@
-const homebridgeLib = require('homebridge-lib')
-const {
-   hsvToRgb, rgbToHsv
-} = homebridgeLib.Colour
-
 
 class ColorConfigData {
 	constructor(maxColorTemperature, minColorTemperature) {
@@ -57,37 +52,41 @@ class RgbColor {
 	}
 };
 
+class HsvColor {
+	constructor(h, s, v = 100) {
+		this.h = h;
+		this.s = s;
+		this.v = v;
+	}
+};
+
 class ColorContextData {
-	constructor(colorConfigData, colorMode, colorTemperature, rgbColor, hue = 0, saturation = 0) {
+	constructor(colorConfigData, colorMode, colorTemperature, rgbColor, hsv = undefined) {
 		this.configData = colorConfigData;
 		this.colorMode = colorMode;
 		this.colorTemperature = colorTemperature;
 		this.rgbColor = rgbColor;
-		this.hue = hue;
-		this.saturation = saturation;
+		this.hsv = hsv == undefined ? new HsvColor(0, 0) : hsv;
 	}
 };
 
 class Color {
-	constructor(colorContextData) {
+	constructor(colorContextData, log) {
 		this.data = colorContextData;
-
+		this.log = log;
 
 		if (this.supportsColorTemperature() && this.supportsRgb())
 		{
 			// Sync colorTemperature and rgbColor based on current color mode.
-			const hsv = (() => {
+			this.data.hsv = (() => {
 
 				if (this.getColorMode() == ColorModeColorTemperature) {
 					let rgb = Color.MiredsToRgb(this.getColorTemperature());
-					return rgbToHsv(rgb.r, rgb.g, rgb.b);
+					return Color.RgbToHsv(rgb);
 				}
 
-				return  rgbToHsv(this.getRgb().r, this.getRgb().g, this.getRgb().b);
+				return  Color.RgbToHsv(this.getRgb());
 			})();
-
-			this.data.hue = hsv.h;
-			this.data.saturation = hsv.s;
 		}
 	}
 
@@ -115,34 +114,32 @@ class Color {
 		}
 	}
 
-	getHue() { return this.data.hue; }
+	getHue() { return this.getHsv().h; }
 	setHue(hue) {
 		assert(this.supportsRgb(), 'Must not set hue when rgbColor is unsupported.');
-		this.data.hue = hue;
+		this.data.hsv.h = hue;
 		this.updateFromHsv();
 		this.data.colorMode = ColorModeRgb;
 	}
 
-	getSaturation() { return this.data.saturation; }
+	getSaturation() { return this.getHsv().s; }
 	setSaturation(saturation) {
 		assert(this.supportsRgb(), 'Must not set saturation when rgbColor is unsupported.');
-		this.data.saturation = saturation;
+		this.data.hsv.s = saturation;
 		this.updateFromHsv();
 		this.data.colorMode = ColorModeRgb;
 	}
 
 	getRgb() { return this.data.rgbColor; }
 
+	getHsv() { return this.data.hsv; }
+
 	updateHsvFromRgb(rgb) {
-
-		const {h, s, v} = rgbToHsv(rgb.r, rgb.g, rgb.b);
-
-		this.data.hue = h;
-		this.data.saturation = s;
+		this.data.hsv = Color.RgbToHsv(rgb);
 	}
 
 	updateFromHsv() {
-		this.data.rgbColor = hsvToRgb(this.data.hue, this.data.saturation);
+		this.data.rgbColor = Color.HsvToRgb(this.data.hsv);
 	}
 
 	// Deep copy context data
@@ -169,28 +166,28 @@ class Color {
 		return colorConfig != undefined ? colorConfig.data : defaultColorConfig;
 	}
 
-	static ByteRgbToNormalizedRgb(r, g, b) {
+	static ByteRgbToNormalizedRgb(rgb) {
 		return new RgbColor(
-			r / 255.0,
-			g / 255.0,
-			b / 255.0
+			rgb.r / 255.0,
+			rgb.g / 255.0,
+			rgb.b / 255.0
 		);
 	}
 
-	static SengledRgbToNormalizedRgb(r, g, b) {
-		return Color.ByteRgbToNormalizedRgb(r, g, b);
+	static SengledRgbToNormalizedRgb(rgb) {
+		return Color.ByteRgbToNormalizedRgb(rgb);
 	}
 
-	static NormailizedRgbToByteRgb(r, g, b) {
+	static NormalizedRgbToByteRgb(rgb) {
 		return new RgbColor(
-			Math.round(r * 255),
-			Math.round(g * 255),
-			Math.round(b * 255)
+			Math.round(rgb.r * 255),
+			Math.round(rgb.g * 255),
+			Math.round(rgb.b * 255)
 		);
 	}
 
-	static NormailizedRgbToSengledRgb(r, g, b) {
-		return Color.NormalizedRgbToByteRgb(r, g, b);
+	static NormalizedRgbToSengledRgb(rgb) {
+		return Color.NormalizedRgbToByteRgb(rgb);
 	}
 
 	static SengledColorTemperatureToMireds(colorTemperature, configData) {
@@ -234,7 +231,7 @@ class Color {
 
 	// Adapted from Tanner Helland's algorithm:
 	// https://tannerhelland.com/2012/09/18/convert-temperature-rgb-algorithm-code.html
-	// Modified to produce normailized rgb.
+	// Modified to produce normalized rgb.
 	static KelvinsToRgb(tmpKelvin) {
 
 		let tmpCalc, r, g, b;
@@ -296,6 +293,104 @@ class Color {
 
 		return new RgbColor(r, g, b);
 	}
+
+	// Implemented from https://en.wikipedia.org/wiki/HSL_and_HSV
+	// r, g, and b are[ 0-1.0]
+	// h is [0,360], s is [0-100], and v is [0-100]
+	static RgbToHsv(rgb)
+	{
+		let r = rgb.r;
+		let g = rgb.g;
+		let b = rgb.b;
+
+	        let max = Math.max(r, g, b);
+	        let min = Math.min(r, g, b);
+
+	        let v = max;
+	        let c = max - min;
+	        let l = v - c/2;
+
+		let h;
+		switch(max) {
+			case min: h = 0;
+			case r: h = (6 + ((g - b) / c)) % 6; break;
+			case g: h = (2 + ((b - r) / c)); break;
+			case b: h = (4 + ((r - g) / c)); break;
+		}
+
+		let s = max == 0 ? 0 : c / v;
+
+	        return new HsvColor(
+	                Math.round(h * 60),
+	                Math.round(s * 100),
+	                Math.round(v * 100)
+	        );
+	}
+
+	// Implemented from https://en.wikipedia.org/wiki/HSL_and_HSV
+	// r, g, and b are[ 0-1.0]
+	// h is [0,360], s is [0-100], and v is [0-100]
+	static HsvToRgb(hsv) {
+
+		let h = hsv.h;
+		let s = hsv.s;
+		let v = hsv.v;
+
+		s /= 100.0;
+		v /= 100.0;
+
+	        let c = v * s;
+	        let H = h / 60;
+	        let x = c * (1 - Math.abs((H % 2) - 1));
+
+	        let R, G, B;
+
+	        if (H < 1)
+	        {
+	                R = c;
+	                G = x;
+	                B = 0;
+	        }
+	        else if (H < 2)
+	        {
+	                R = x;
+	                G = c;
+	                B = 0;
+	        }
+	        else if (H < 3)
+	        {
+	                R = 0;
+	                G = c;
+	                B = x;
+	        }
+	        else if (H < 4)
+	        {
+	                R = 0;
+	                G = x;
+	                B = c;
+	        }
+	        else if (H < 5)
+	        {
+	                R = x;
+	                G = 0;
+	                B = c;
+	        }
+	        else // (H < 6)
+	        {
+	                R = c;
+	                G = 0;
+	                B = x;
+	        }
+
+	        let m = v - c;
+
+	        let r = R + m;
+	        let g = G + m;
+	        let b = B + m;
+
+	        return new RgbColor (r, g, b );
+	}
+
 };
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,36 @@
 {
   "name": "homebridge-sengled-bulbs",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
+      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "array-flatten": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+    },
     "axios": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
         "follow-redirects": "^1.14.0"
       }
@@ -21,25 +44,557 @@
         "pify": "^5.0.0"
       }
     },
+    "bonjour-hap": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.6.3.tgz",
+      "integrity": "sha512-qyLU96ICCYbpOFiMCjA3aNYH5Jc83XH1YX6+EXWukyyiNXzXH2LZv8AVmGW33FceF3gfUM4jYoKX2xChtNDUnA==",
+      "requires": {
+        "array-flatten": "^2.1.2",
+        "deep-equal": "^2.0.5",
+        "ip": "^1.1.5",
+        "multicast-dns": "^7.2.3",
+        "multicast-dns-service-types": "^1.1.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "deep-equal": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
+      "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "es-get-iterator": "^1.1.1",
+        "get-intrinsic": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.1.1",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "dns-packet": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.0.tgz",
+      "integrity": "sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==",
+      "requires": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      }
+    },
+    "es-get-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
+      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.0",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.1.0",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "follow-redirects": {
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
       "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "homebridge-lib": {
+      "version": "5.1.17",
+      "resolved": "https://registry.npmjs.org/homebridge-lib/-/homebridge-lib-5.1.17.tgz",
+      "integrity": "sha512-9wZas7bqbfgkDcuUjRHRRTLA0VqkixqMqZMiTgq6lpMBzenkck1EM7mwMPsw7O0yKgybXJnyuy9BwhDFRkUuMA==",
+      "requires": {
+        "bonjour-hap": "^3.6.3",
+        "chalk": "^4.1.2",
+        "semver": "^7.3.5"
+      }
+    },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+    },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+    },
+    "is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
+    },
+    "is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
+    "is-weakset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
+    "multicast-dns": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.4.tgz",
+      "integrity": "sha512-XkCYOU+rr2Ft3LI6w4ye51M3VK31qJXFIxu0XLw169PtKG0Zx47OrXeVW/GCYOfpC9s1yyyf1S+L8/4LY0J9Zw==",
+      "requires": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      }
+    },
+    "multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "object-inspect": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+    },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
+    },
     "pify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
       "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
+    "tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      }
+    },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.5",
+        "foreach": "^2.0.5",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.7"
+      }
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-sengled-bulbs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A unoffical Homebridge plugin for controlling sengled accessories.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "axios": "^0.21.4",
     "axios-cookiejar-support": "^1.0.1",
     "moment": "^2.29.1",
-    "tough-cookie": "^4.0.0"
+    "tough-cookie": "^4.0.0",
+    "homebridge-lib": "^5.1.17"
   },
   "keywords": [
     "siri",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "axios": "^0.21.4",
     "axios-cookiejar-support": "^1.0.1",
     "moment": "^2.29.1",
-    "tough-cookie": "^4.0.0",
-    "homebridge-lib": "^5.1.17"
+    "tough-cookie": "^4.0.0"
   },
   "keywords": [
     "siri",


### PR DESCRIPTION
Add support for hue and saturation characteristics when bulbs support it.  Light bulb support for brightness, color temperature, and hue/saturation are determined by the presence of the corresponding fields in the data retrieved from the Sengled service, but this has only been tested on E12-N1E which supports them all.  If this approach doesn't work for lightbulbs that do not have some of these characteristics, it's easy to move to a table based approach for choosing capabilities.

The E12-N1E has a "white" light mode and a "color" light mode.  This PR treats color temperature changes as switching to "white" light mode and setting of hue/saturation as switching into "color" light mode.  When temperature is set, this change calculates hue and saturation values to update to homebridge so that the cursor in the home app on the color temperature tab appears to match the temperature rather than the hue saturation.  This seems to result in some jumping around on the color temperature wheel, but this should only affect lights that support color temp and RGB.

Added an instanced SengledLightAccessory to handle callbacks and resolve some issues with state. Added a common method for updating homebridge context from sengled device state.  As part of this, I removed the calls to addCharacteristc and a uuid argument to characteristic construction that didn't seem to do anything.  It seems that calls to getCharacteristic add the optional characteristic if it's not there.  Some callbacks for getters/setters were commented out.  Enabled those and also fixed up some error reporting to be more consistent.

Color.js is added to help keep hue/sat in sync when in color temp mode, and handle the various color conversions.

Added firmware revision characteristic and plumbed through the value from sengled device data.

Modified brightness min/max to be 0-255 to match sengled encoding so scaling is no longer needed to map the ranges.  Added a configuration option to set the min/max color temperature values based on matching product number.  Only the E12-N1E has values here.  Other bulbs will fall back to the previous homebridge defaults.

Client has an API added for setting RGB color.  This has a quirk that it also turns on the light if it is off, which is inconsistent with setting color temp.  For now, updating homekit power state when an RGB color is set.

