### PR TITLE
Fix crash on upgrade.  Add alternate login.  Other fixes

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -38,6 +38,20 @@
                 "type": "boolean",
                 "default": false,
                 "description": "This will enable information from the plugin."
+            },
+            "Timeout": {
+                "title": "Timeout",
+                "type": "integer",
+                "default": 4000,
+                "minimum": 2000,
+                "maximum": 30000,
+                "description": "The timeout in milliseconds to use for calls to the Sengled Web API. High values may result in other errors."
+            },
+            "AlternateLoginApi": {
+                "title": "AlternateLoginApi",
+                "type": "boolean",
+                "default": false,
+                "description": "Uses an alternative login API if for some reason logins fail even with increased timeout."
             }
         }
     }

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ SengledHubPlatform.prototype.deviceDiscovery = function() {
 		}
 
 		if (me.debug) me.log("Discovery complete");
-		if (me.debug) me.log(JSON.stringify(me.accessories, null, 4));
+		// if (me.debug) me.log(JSON.stringify(me.accessories, null, 4));
 	}).catch((err) => {
 		this.log("Failed deviceDiscovery: ");
 		this.log(me.debug ? err : err.message);

--- a/index.js
+++ b/index.js
@@ -136,7 +136,6 @@ SengledHubPlatform.prototype.deviceDiscovery = function() {
 	}).catch((err) => {
 		this.log("Failed deviceDiscovery: ");
 		this.log(me.debug ? err : err.message);
->>>>>>> Logins are currently timing out via the existing method, but this seems to work with a higher timout.
 	});
 };
 

--- a/index.js
+++ b/index.js
@@ -125,7 +125,11 @@ SengledHubPlatform.prototype.deviceDiscovery = function() {
 		}
 
 		if (me.debug) me.log("Discovery complete");
-		// if (me.debug) me.log(JSON.stringify(me.accessories, null, 4));
+		if (me.debug) me.log(JSON.stringify(me.accessories, null, 4));
+	}).catch((err) => {
+		this.log("Failed deviceDiscovery: ");
+		this.log(me.debug ? err : err.message);
+>>>>>>> Logins are currently timing out via the existing method, but this seems to work with a higher timout.
 	});
 };
 
@@ -330,26 +334,28 @@ SengledLightAccessory.prototype.getPowerState = function(callback) {
 	let me = this;
 	if (this.debug) this.log("Getting device PowerState: " + this.getName() + " status");
 
-	return this.client.login(this.username, this.password).then(() => {
-		return this.client.getDevices();
-	}).then(devices => {
-		return devices.find((device) => {
-			return device.id.includes(this.getId());
-		});
-	}).then((device) => {
-		if (typeof device === 'undefined') {
-			if (this.debug) this.log("Removing undefined device", this.getName());
-			this.platform.removeAccessory(this.accessory);
-		} else {
-			if (this.debug) this.log("getPowerState complete: " + device.name + " " + this.getName() + " is " + device.status);
-			this.context.status = device.status;
-			callback(null, device.status);
-		}
-	}).catch((err) => {
-		this.log("Failed to get power state");
-		this.log(err.message);
-		callback(err);
-	});
+	callback(null, this.context.status);
+
+//	return this.client.login(this.username, this.password).then(() => {
+//		return this.client.getDevices();
+//	}).then(devices => {
+//		return devices.find((device) => {
+//			return device.id.includes(this.getId());
+//		});
+//	}).then((device) => {
+//		if (typeof device === 'undefined') {
+//			if (this.debug) this.log("Removing undefined device", this.getName());
+//			this.platform.removeAccessory(this.accessory);
+//		} else {
+//			if (this.debug) this.log("getPowerState complete: " + device.name + " " + this.getName() + " is " + device.status);
+//			this.context.status = device.status;
+//			callback(null, device.status);
+//		}
+//	}).catch((err) => {
+//		this.log("Failed to get power state");
+//		this.log(err.message);
+//		callback(err);
+//	});
 };
 
 SengledLightAccessory.prototype.setBrightness = function(brightness, callback) {

--- a/index.js
+++ b/index.js
@@ -334,7 +334,7 @@ SengledLightAccessory.prototype.setPowerState = function(powerState, callback) {
 		return this.client.deviceSetOnOff(this.getId(), powerState);
 	}).then(() => {
 		this.context.status = powerState;
-		callback(null, powerState);
+		callback();
 	}).catch((err) => {
 		this.log("Failed to set power state to", powerState);
 		this.log(err);

--- a/index.js
+++ b/index.js
@@ -335,27 +335,6 @@ SengledLightAccessory.prototype.getPowerState = function(callback) {
 	if (this.debug) this.log("Getting device PowerState: " + this.getName() + " status");
 
 	callback(null, this.context.status);
-
-//	return this.client.login(this.username, this.password).then(() => {
-//		return this.client.getDevices();
-//	}).then(devices => {
-//		return devices.find((device) => {
-//			return device.id.includes(this.getId());
-//		});
-//	}).then((device) => {
-//		if (typeof device === 'undefined') {
-//			if (this.debug) this.log("Removing undefined device", this.getName());
-//			this.platform.removeAccessory(this.accessory);
-//		} else {
-//			if (this.debug) this.log("getPowerState complete: " + device.name + " " + this.getName() + " is " + device.status);
-//			this.context.status = device.status;
-//			callback(null, device.status);
-//		}
-//	}).catch((err) => {
-//		this.log("Failed to get power state");
-//		this.log(err.message);
-//		callback(err);
-//	});
 };
 
 SengledLightAccessory.prototype.setBrightness = function(brightness, callback) {

--- a/index.js
+++ b/index.js
@@ -374,10 +374,13 @@ SengledLightAccessory.prototype.getBrightness = function(callback) {
 
 SengledLightAccessory.prototype.setColorTemperature = function(colortemperature, callback) {
 	let me = this;
-	if (me.debug) me.log("++++ setColortemperature: " + me.context.name + " status colortemperature to " + colortemperature);
-	let sengledColorTemperature = colortemperature || this.color.getMinColorTemperature();
-	sengledColorTemperature = Color.MiredsToSengledColorTemperature(sengledColorTemperature, this.color.getConfigData());
-	if (me.debug) me.log("++++ Sending device: " + this.getName() + " status colortemperature to " + colortemperature);
+	if (me.debug) me.log("++++ setColortemperature: " + me.getName() + " status colortemperature to " + colortemperature);
+
+	// Convert to sengleded color temperature range
+	colortemperature = colortemperature || this.color.getMinColorTemperature();
+	let sengledColorTemperature = Color.MiredsToSengledColorTemperature(colortemperature, this.color.getConfigData());
+
+	if (me.debug) me.log("++++ Sending device: " + this.getName() + " status colortemperature to " + sengledColorTemperature);
 
 	return this.client.login(this.username, this.password).then(() => {
 		return this.client.deviceSetColorTemperature(this.getId(), sengledColorTemperature);
@@ -416,7 +419,7 @@ SengledLightAccessory.prototype.setHue = function(hue, callback) {
 };
 
 SengledLightAccessory.prototype.getHue = function(callback) {
-	if (this.debug) this.log("+++getHue: " + this.name + "  hue: " + this.color.getHue());
+	if (this.debug) this.log("+++getHue: " + this.getName() + "  hue: " + this.color.getHue());
 
 	callback(null, this.color.getHue());
 };

--- a/index.js
+++ b/index.js
@@ -59,11 +59,10 @@ SengledHubPlatform.prototype.configureAccessory = function(accessory) {
 SengledHubPlatform.prototype.didFinishLaunching = function() {
 	let me = this;
 	if (me.debug) me.log("didFinishLaunching invoked ");
-	if (me.debug) me.log(me.accessories);
 
 	// // dev-mode
 	// for (let index in me.accessories) {
-	// 	me.removeAccessory(me.accessories[index]);
+	// 	me.removeAccessory(me.accessories[index].accessory);
 	// }
 
 	this.deviceDiscovery();
@@ -132,7 +131,7 @@ SengledHubPlatform.prototype.deviceDiscovery = function() {
 		});
 
 		if (me.debug) me.log("Discovery complete");
-		if (me.debug) me.log(me.accessories);
+		if (me.debug) for(let key in me.accessories) {me.log(me.accessories[key].accessory);}
 	}).catch((err) => {
 		this.log("Failed deviceDiscovery: ");
 		this.log(me.debug ? err : err.message);
@@ -282,8 +281,7 @@ SengledLightAccessory.prototype.BindService = function() {
 // Bind callbacks for light properties and update context data.
 SengledLightAccessory.prototype.BindAndUpdateAccessory = function(data) {
 	let me = this;
-	if (me.debug) me.log("BindAndUpdateAccessory invoked: ");
-	if (me.debug) me.log(accessory);
+	if (me.debug) me.log("BindAndUpdateAccessory invoked: " + this.accessory.displayName);
 
 	// Update context data for accessory.
 	UpdateContextFromDevice(this.accessory.context, data);

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ function SengledHubPlatform(log, config, api) {
 	this.info = config['info'] || true;
 	this.username = config['username'];
 	this.password = config['password'];
-	this.useAlternateLoginApi = config['AlternateLoginApi'];
-	this.timeout = config['Timeout'];
+	this.useAlternateLoginApi = config['AlternateLoginApi'] ?  config['AlternateLoginApi'] : false;
+	this.timeout = config['Timeout'] ? config['Timeout'] : 4000;
 
 	if (api) {
 		this.api = api;

--- a/index.js
+++ b/index.js
@@ -22,13 +22,15 @@ function SengledHubPlatform(log, config, api) {
 	this.info = config['info'] || true;
 	this.username = config['username'];
 	this.password = config['password'];
+	this.useAlternateLoginApi = config['AlternateLoginApi'];
+	this.timeout = config['Timeout'];
 
 	if (api) {
 		this.api = api;
 		this.api.on('didFinishLaunching', this.didFinishLaunching.bind(this));
 	}
 
-	this.client = new ElementHomeClient(log, this.debug, this.info);
+	this.client = new ElementHomeClient(this.useAlternateLoginApi, this.timeout, log, this.debug, this.info);
 }
 
 SengledHubPlatform.prototype.configureAccessory = function(accessory) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -108,7 +108,8 @@ login(username, password) {
 			if (me.debug || me.info) me.log("login via api");
 		}
 
-		// Return codes These are not currenlty being checked.  Only 0 and 1 have been verified to be correct.
+		// Return codes These are not currenlty being checked.  Only 0 and 1 have been verified to
+		// match these descriptions:
 		// -1 - Server error.
 		//  0 - Success
 		//  1 - "参数错误" - An argument is incorrect

--- a/lib/client.js
+++ b/lib/client.js
@@ -67,18 +67,20 @@ class Brightness  {
 
 class ElementHomeClient {
 
-  constructor(log, debug = false, info = false) {
+  constructor(useAlternateLoginApi, timeout, log, debug = false, info = false) {
+
+    this.useAlternateLoginApi = useAlternateLoginApi;
 
     this.client = axios.create({
-      timeout: 4000,
+      timeout: timeout,
       jar: cookieJar,
       withCredentials: true,
       responseType: 'json'
     });
     this.client.defaults.headers.post['Content-Type'] = 'application/json';
-    this.log = log
-	  this.debug = debug
-    this.info = info
+    this.log = log;
+    this.debug = debug;
+    this.info = info;
  		if (this.info) this.log("Starting Sengled Client...");
 	  this.log("Starting Sengled Client...");
     this.lastLogin = moment('2000-01-01')
@@ -108,32 +110,53 @@ login(username, password) {
 			if (me.debug || me.info) me.log("login via api");
 		}
 
-		// Return codes These are not currenlty being checked.  Only 0 and 1 have been verified to
-		// match these descriptions:
-		// -1 - Server error.
-		//  0 - Success
-		//  1 - "参数错误" - An argument is incorrect
-		//  2 - "用户名或密码错误" Incorrect password
-		//  3 - "用户名不存在: Incorrect username
+		if (!this.useAlternateLoginApi) {
 
-		this.client.post('https://ucenter.cloud.sengled.com/user/app/customer/v2/AuthenCross.json',
-		{
-			'uuid': this.uuid,
-			'user': username,
-			'pwd': password,
-			'osType': 'android',
-			'productCode': 'life',
-			'appCode': 'life'
-		}).then((response) => {
-			this.jsessionid = response.data.jsessionId;
-			this.lastLogin = moment();
-			this.loginResponse = response;
-			if (me.debug) me.log("logged in to Sengled");
-			fulfill(response);
-		}).catch(function (error) {
-			reject(error);
-		});
+			this.client.post('https://us-elements.cloud.sengled.com/zigbee/customer/login.json',
+			{
+				'uuid': this.uuid,
+				'user': username,
+				'pwd': password,
+				'os_type': 'android'
+			}).then((response) => {
+				this.jsessionid = response.data.jsessionId;
+				this.lastLogin = moment();
+				this.loginResponse = response;
+				if (me.debug) me.log("logged in to Sengled");
+				fulfill(response);
+			}).catch(function (error) {
+				reject(error);
+			});
+		}
+		else {
+			// Return codes These are not currenlty being checked.  Only 0 and 1 have been verified to
+			// match these descriptions:
+			// -1 - Server error.
+			//  0 - Success
+			//  1 - "参数错误" - An argument is incorrect
+			//  2 - "用户名或密码错误" Incorrect password
+			//  3 - "用户名不存在: Incorrect username
+
+			this.client.post('https://ucenter.cloud.sengled.com/user/app/customer/v2/AuthenCross.json',
+			{
+				'uuid': this.uuid,
+				'user': username,
+				'pwd': password,
+				'osType': 'android',
+				'productCode': 'life',
+				'appCode': 'life'
+			}).then((response) => {
+				this.jsessionid = response.data.jsessionId;
+				this.lastLogin = moment();
+				this.loginResponse = response;
+				if (me.debug) me.log("logged in to Sengled");
+				fulfill(response);
+			}).catch(function (error) {
+				reject(error);
+			});
+		}
 	});
+
 }
 
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -178,8 +178,8 @@ login(username, password) {
 					if (response.data.ret == 100) {
 						reject(response.data);
 					} else {
-						let deviceInfos = response.data.deviceInfos;
-						let lampInfos = _ArrayFlatMap(deviceInfos, i => i.lampInfos);
+						let deviceInfos = response.data.hasOwnProperty('deviceInfos') ? response.data.deviceInfos : [];
+						let lampInfos = _ArrayFlatMap(deviceInfos, i => i.hasOwnProperty('lampInfos') ? i.lampInfos : []);
 						let devices = lampInfos.map((device) => {
 
 						let attributes = device.attributes;

--- a/lib/client.js
+++ b/lib/client.js
@@ -119,7 +119,7 @@ login(username, password) {
 				'pwd': password,
 				'os_type': 'android'
 			}).then((response) => {
-				this.jsessionid = response.data.jsessionId;
+				this.jsessionid = response.data.jsessionid;
 				this.lastLogin = moment();
 				this.loginResponse = response;
 				if (me.debug) me.log("logged in to Sengled");

--- a/lib/client.js
+++ b/lib/client.js
@@ -70,7 +70,6 @@ class ElementHomeClient {
   constructor(log, debug = false, info = false) {
 
     this.client = axios.create({
-      baseURL: 'https://us-elements.cloud.sengled.com/zigbee/',
       timeout: 4000,
       jar: cookieJar,
       withCredentials: true,
@@ -89,43 +88,52 @@ class ElementHomeClient {
  		if (this.debug) this.log("set cache duration " + this.cacheDuration);
   }
 
-  login(username, password) {
+login(username, password) {
 	let me = this;
 	if (me.debug) me.log("login invoked " + username);
-  if (me.debug) me.log("login sessionid " + this.jsessionid);
-    // If token has been set in last 24 hours, don't log in again
-    // if (this.lastLogin.isAfter(moment().subtract(24, 'hours'))) {
-    //     return Promise.resolve();
-    // }
+ 	if (me.debug) me.log("login sessionid " + this.jsessionid);
+	// If token has been set in last 24 hours, don't log in again
+	// if (this.lastLogin.isAfter(moment().subtract(24, 'hours'))) {
+	//     return Promise.resolve();
+	// }
 
 
-  return new Promise((fulfill, reject) => {
-    if (this.jsessionid != null) {
-      this.log("Cookie found, skipping login request.");
-      if (me.debug) me.log("login via cookie");
-      fulfill(this.loginResponse);
-    } else {
-      if (me.debug || me.info) me.log("login via api"); }
-    this.client.post('/customer/login.json',
-    {
-      'uuid':this.uuid,
-      'user': username,
-      'pwd': password,
-      'os_type': 'android'
-    }).then((response) => {
-      this.jsessionid = response.data.jsessionid;
-      this.lastLogin = moment();
-      this.loginResponse = response;
-      if (me.debug) me.log("logged in to Sengled");
-      fulfill(response);
-    }).catch(function (error) {
-      reject(error);
-    });
+	return new Promise((fulfill, reject) => {
+		if (this.jsessionid != null) {
+			this.log("Cookie found, skipping login request.");
+			if (me.debug) me.log("login via cookie");
+			fulfill(this.loginResponse);
+		}
+		else {
+			if (me.debug || me.info) me.log("login via api");
+		}
 
-  });
+		// Return codes These are not currenlty being checked.  Only 0 and 1 have been verified to be correct.
+		// -1 - Server error.
+		//  0 - Success
+		//  1 - "参数错误" - An argument is incorrect
+		//  2 - "用户名或密码错误" Incorrect password
+		//  3 - "用户名不存在: Incorrect username
 
-
-  }
+		this.client.post('https://ucenter.cloud.sengled.com/user/app/customer/v2/AuthenCross.json',
+		{
+			'uuid': this.uuid,
+			'user': username,
+			'pwd': password,
+			'osType': 'android',
+			'productCode': 'life',
+			'appCode': 'life'
+		}).then((response) => {
+			this.jsessionid = response.data.jsessionId;
+			this.lastLogin = moment();
+			this.loginResponse = response;
+			if (me.debug) me.log("logged in to Sengled");
+			fulfill(response);
+		}).catch(function (error) {
+			reject(error);
+		});
+	});
+}
 
 
   getDevices() {
@@ -141,7 +149,7 @@ class ElementHomeClient {
 		}
 
 		return new Promise((fulfill, reject) => {
-			this.client.post('/device/getDeviceDetails.json', {})
+			this.client.post('https://us-elements.cloud.sengled.com/zigbee/device/getDeviceDetails.json', {})
 				.then((response) => {
 					if (response.data.ret == 100) {
 						reject(response.data);
@@ -216,6 +224,7 @@ class ElementHomeClient {
 							color: color
 						};
 
+
 						// Cache this device and set the last time the cache was updated.
 						me.cache[newDevice.id] = newDevice;
 						me.lastCache = moment();
@@ -233,7 +242,7 @@ class ElementHomeClient {
 	let me = this;
 	if (me.debug) me.log("userInfo invoked ");
     return new Promise((fulfill, reject) => {
-      this.client.post('/customer/getUserInfo.json', {})
+      this.client.post('https://us-elements.cloud.sengled.com/zigbee/customer/getUserInfo.json', {})
       .then((response) => {
         if (response.data.ret == 100) {
           reject(response.data);
@@ -250,7 +259,7 @@ class ElementHomeClient {
     let me = this;
     if (me.debug) me.log('onOff ' + deviceId + ' ' + onoff);
     return new Promise((fulfill, reject) => {
-      this.client.post('/device/deviceSetOnOff.json', {"onoff": onoff ? 1 : 0,"deviceUuid": deviceId})
+      this.client.post('https://us-elements.cloud.sengled.com/zigbee/device/deviceSetOnOff.json', {"onoff": onoff ? 1 : 0,"deviceUuid": deviceId})
       .then((response) => {
         if (response.data.ret == 100) {
           reject(response.data);
@@ -267,7 +276,7 @@ class ElementHomeClient {
   deviceSetBrightness(deviceId, brightness) {
     return new Promise((fulfill, reject) => {
         this.client
-            .post('/device/deviceSetBrightness.json', {
+            .post('https://us-elements.cloud.sengled.com/zigbee/device/deviceSetBrightness.json', {
                 brightness: brightness,
                 deviceUuid: deviceId
             })
@@ -288,7 +297,7 @@ class ElementHomeClient {
 deviceSetColorTemperature(deviceId, colorTemperature) {
     return new Promise((fulfill, reject) => {
         this.client
-            .post('/device/deviceSetColorTemperature.json', {
+            .post('https://us-elements.cloud.sengled.com/zigbee/device/deviceSetColorTemperature.json', {
                 colorTemperature: colorTemperature,
                 deviceUuid: deviceId
             })
@@ -309,7 +318,7 @@ deviceSetColorTemperature(deviceId, colorTemperature) {
 deviceSetRgbColor(deviceId, rgb) {
     return new Promise((fulfill, reject) => {
         this.client
-            .post('/device/deviceSetGroup.json', {
+            .post('https://us-elements.cloud.sengled.com/zigbee/device/deviceSetGroup.json', {
 		cmdId: 129,
 		deviceUuidList: [{ deviceUuid: deviceId}],
 		rgbColorR: rgb.r,

--- a/lib/color.js
+++ b/lib/color.js
@@ -1,3 +1,4 @@
+'use strict';
 
 class ColorConfigData {
 	constructor(maxColorTemperature, minColorTemperature) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-sengled-bulbs",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A unoffical Homebridge plugin for controlling sengled accessories.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR resolves [new version crashing homebridge v0.0.4 #8](https://github.com/sammy1881/homebridge-sengled-bulbs/issues/8].  The main issue was that context data was read during configureAccessory, but homebridge may be restoring a cached accessory from a previous version that didn't have the new properties.  This change resolves this issue by separating SengledLightAccessory into two steps, construction and BindAndUpdateAccessory.  The former sets basic properties, while the latter is responsible for one time initialization of the service and characteristics and updating state with the latest information from Sengled APi's.  A previous attempt at this fix had an issue that bound multiple listeners to each characteristic during the timeout for device discovery.  That has been resolved in this PR.

Additionally, this PR adds an off-by-default option for an alternate login API.  The current login API started timing out for me, even with timeouts as high as 20,000 ms.   This option also adds a slider for the timeout of the axios api.

Other issues fixed:

- In the prior change that introduced issue #8 I also regressed accessory renamed, this is fixed. Also added GetDeviceName function so that accessory creation and check for rename used the same logic to determine name.
- In homebridge debug mode, I saw the warning: "Characteristic 'On': SET handler returned write response value, though the characteristic doesn't support write response."  The issue was that the callback for the set handler was returning a value, but shouldn't have.
- Added a catch handler to device discovery.  When this timed out it was throwing an unhandled error to homebridge.
- getHue() debug logging showed undefined for accessory name.  Fixed with gitName() method. 
- Removed some redundant whole accessory logging.
- Changed homebridge state updates to use updateValue instead of getValue.  The latter invokes the onGet callback while the former just sets the state directly.
- Removed sengled API state checking in the On characteristic get handler due to timeouts or warnings from homebridge that we are slowing homebridge down.  Toggling the light corrects the state if it's modified by an outside source, and periodic device discovery will also correct it.
- Fixed the second logging instance in setColorTemperature to report the sengled color temperature value that is actually sent to the API.  The first already logs the mired value set by homebridge.
- Added some handling for the case that device discovery reports no devices.